### PR TITLE
Use github pages

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,21 @@
+name: Build static content to Pages
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
+        with:
+          node-version: '16.20.2'
+      - name: Run build
+        run: yarn run build; ls -al

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,4 +18,7 @@ jobs:
         with:
           node-version: '16.20.2'
       - name: Run build
-        run: yarn run build; ls -al
+        run: |
+          yarn install
+          yarn run build
+          ls -al

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -1,0 +1,38 @@
+name: Deploy static content to Pages
+
+on:
+  push:
+    branches: ["master"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+      - name: Setup node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
+        with:
+          node-version: '16.20.2'
+      - name: Setup Pages
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        with:
+          path: './build/'
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4

--- a/.github/workflows/pages.yaml
+++ b/.github/workflows/pages.yaml
@@ -27,6 +27,10 @@ jobs:
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '16.20.2'
+      - name: Run build
+        run: |
+          yarn install
+          yarn run build
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Upload artifact

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
 package-lock.json
+.eslintcache

--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@ It is a React app which we currently host at Netlify.
 
 ### Development
 
-Ensure that a recent version of Node.js is installed on your machine.
+Ensure that you start the app in a docker container with Node.js 16 such as `node:16.20.2-bookworm-slim`.
 
-    cd nycmesh-configgen
-    npm install
-    npm start
+    docker run --rm -it --entrypoint /bin/bash -v `pwd`:/nycmesh-configgen node:16.20.2-bookworm-slim
+    cd /nycmesh-configgen
+    yarn install
+    yarn start
 
 This runs the app in development mode and opens a Chrome browser.
 

--- a/public/404.html
+++ b/public/404.html
@@ -1,0 +1,6 @@
+
+<html>
+  <head>
+    <meta http-equiv="refresh" content="0; url=https://configgen.nycmesh.net">
+  </head>
+</html>

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,0 @@
-# Redirect default Netlify subdomain to primary domain
-https://nycmesh-configgen.netlify.com/* https://configgen.nycmesh.net/:splat 301!


### PR DESCRIPTION
Deploy configgen via github pages. This is currently deployed with netlify, but it does not work anymore, so we can't push out updates: https://app.netlify.com/projects/nycmesh-configgen/deploys/684e4c848c10b80008b04372

- [ ] Merge https://github.com/nycmeshnet/nycmesh-dns/pull/223
- [ ] Setup pages in the UI